### PR TITLE
Changed API version to 1.13

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: Bedrock
 version: '${project.version}'
 main: me.jasper1229.bedrock.Bedrock
-api-version: 1.16
+api-version: 1.13
 authors: [ Jasper1229 ]
 description: This plugin provides basic commands that are the bedrock of all of your servers!
 commands:
@@ -10,4 +10,4 @@ commands:
   frog:
     permission: bedrock.frog
   find:
-    permission: bedrock.find
+    permission: bedrock.find 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -10,4 +10,4 @@ commands:
   frog:
     permission: bedrock.frog
   find:
-    permission: bedrock.find 
+    permission: bedrock.find


### PR DESCRIPTION
API version 1.13 allows for backwards compatibility from 1.12 - 1.16, otherwise Paper will throw an exception when the plugin attempts to load specifying that your plugin uses an invalid API version. This will not happen on 1.8 - 1.12, but it's still an important change to allow your plugin to be compatible with versions 1.12 - 1.16. I know you're still learning Spigot, so I'm just trying to give you tips that you won't have to learn later on :)

Also, with pull requests, you can click the "Files Changed" tab to view all the changes within the pull request. If you approve it, you can click the green "Merge" button below this comment to commit the changes to your project. 